### PR TITLE
Improve simtk.unit interoperability

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,4 +1,4 @@
-name: test
+name: openff-units-test
 channels:
   - conda-forge
   - defaults
@@ -14,3 +14,4 @@ dependencies:
   - codecov
   - mypy
   - uncertainties
+  - openmm

--- a/openff/units/simtk.py
+++ b/openff/units/simtk.py
@@ -1,15 +1,19 @@
+import ast
+import operator as op
 from typing import TYPE_CHECKING, List
 
-from openff.utilities import requires_package
+from openff.utilities import has_package, requires_package
 
-if TYPE_CHECKING:
+from openff.units import unit
+
+if has_package("simtk.unit") or TYPE_CHECKING:
     from simtk import unit as simtk_unit
 
 
 @requires_package("simtk.unit")
-def unit_to_string(input_unit):
+def simtk_unit_to_string(input_unit: "simtk_unit.Unit") -> str:
     """
-    Serialize a simtk.unit.Unit and return it as a string.
+    Convert a simtk.unit.Unit to a string representation.
 
     Parameters
     ----------
@@ -21,13 +25,11 @@ def unit_to_string(input_unit):
     unit_string : str
         The serialized unit.
     """
-    from simtk import unit as simtk_unit
-
     if input_unit == simtk_unit.dimensionless:
         return "dimensionless"
 
     # Decompose output_unit into a tuples of (base_dimension_unit, exponent)
-    unit_string = None
+    unit_string = ""
 
     for unit_component in input_unit.iter_base_or_scaled_units():
         unit_component_name = unit_component[0].name
@@ -37,7 +39,7 @@ def unit_to_string(input_unit):
             contribution = "{}".format(unit_component_name)
         else:
             contribution = "{}**{}".format(unit_component_name, int(unit_component[1]))
-        if unit_string is None:
+        if unit_string == "":
             unit_string = contribution
         else:
             unit_string += " * {}".format(contribution)
@@ -45,22 +47,82 @@ def unit_to_string(input_unit):
     return unit_string
 
 
+def _ast_eval(node):
+    """
+    Performs an algebraic syntax tree evaluation of a unit.
+
+    Parameters
+    ----------
+    node : An ast parsing tree node
+    """
+
+    operators = {
+        ast.Add: op.add,
+        ast.Sub: op.sub,
+        ast.Mult: op.mul,
+        ast.Div: op.truediv,
+        ast.Pow: op.pow,
+        ast.BitXor: op.xor,
+        ast.USub: op.neg,
+    }
+
+    if isinstance(node, ast.Num):  # <number>
+        return node.n
+    elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
+        return operators[type(node.op)](_ast_eval(node.left), _ast_eval(node.right))
+    elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
+        return operators[type(node.op)](_ast_eval(node.operand))
+    elif isinstance(node, ast.Name):
+        # see if this is a simtk unit
+        b = getattr(simtk_unit, node.id)
+        return b
+    # TODO: This toolkit code that had a hack to cover some edge behavior; not clear which tests trigger it
+    elif isinstance(node, ast.List):
+        return ast.literal_eval(node)
+    else:
+        raise TypeError(node)
+
+
+def string_to_simtk_unit(unit_string: str) -> "simtk_unit.Quantity":
+    """
+    Deserializes a simtk.unit.Quantity from a string representation, for
+    example: "kilocalories_per_mole / angstrom ** 2"
+
+
+    Parameters
+    ----------
+    unit_string : dict
+        Serialized representation of a simtk.unit.Quantity.
+
+    Returns
+    -------
+    output_unit: simtk.unit.Quantity
+        The deserialized unit from the string
+    """
+    import ast
+
+    output_unit = _ast_eval(ast.parse(unit_string, mode="eval").body)  # type: ignore
+    return output_unit
+
+
 @requires_package("simtk.unit")
 def from_simtk(simtk_quantity: "simtk_unit.Quantity"):
-    """
-    Convert a SimTK (OpenMM) Quantity to a pint Quantity.
-
-    """
-    from simtk import unit as simtk_unit
-
-    from openff.units import unit
-
     if isinstance(simtk_quantity, List):
         simtk_quantity = simtk_unit.Quantity(simtk_quantity)
     openmm_unit = simtk_quantity.unit
     openmm_value = simtk_quantity.value_in_unit(openmm_unit)
 
-    target_unit = unit_to_string(openmm_unit)
+    target_unit = simtk_unit_to_string(openmm_unit)
     target_unit = unit.Unit(target_unit)
 
     return openmm_value * target_unit
+
+
+@requires_package("simtk.unit")
+def to_simtk(quantity) -> "simtk_unit.Quantity":
+    value = quantity.m
+
+    unit_string = str(quantity.units._units)
+    simtk_unit_ = string_to_simtk_unit(unit_string)
+
+    return value * simtk_unit_

--- a/openff/units/simtk.py
+++ b/openff/units/simtk.py
@@ -99,7 +99,6 @@ def string_to_simtk_unit(unit_string: str) -> "simtk_unit.Quantity":
     output_unit: simtk.unit.Quantity
         The deserialized unit from the string
     """
-    import ast
 
     output_unit = _ast_eval(ast.parse(unit_string, mode="eval").body)  # type: ignore
     return output_unit

--- a/openff/units/tests/test_simtk.py
+++ b/openff/units/tests/test_simtk.py
@@ -1,0 +1,87 @@
+import pytest
+from openff.utilities.testing import skip_if_missing
+from openff.utilities.utilities import has_package
+
+from openff.units import unit
+from openff.units.simtk import from_simtk
+
+if has_package("simtk.unit"):
+    from simtk import unit as simtk_unit
+
+    from openff.units.simtk import simtk_unit_to_string, string_to_simtk_unit, to_simtk
+
+    simtk_quantitites = [
+        4.0 * simtk_unit.nanometer,
+        5.0 * simtk_unit.angstrom,
+        1.0 * simtk_unit.elementary_charge,
+        0.5 * simtk_unit.erg,
+        1.0 * simtk_unit.dimensionless,
+    ]
+
+    pint_quantities = [
+        4.0 * unit.nanometer,
+        5.0 * unit.angstrom,
+        1.0 * unit.elementary_charge,
+        0.5 * unit.erg,
+        1.0 * unit.dimensionless,
+    ]
+else:
+    simtk_quantitites = []
+    pint_quantities = []
+
+
+@skip_if_missing("simtk.unit")
+class TestSimTKUnits:
+    @pytest.mark.parametrize(
+        "simtk_quantity,pint_quantity",
+        [(s, p) for s, p in zip(simtk_quantitites, pint_quantities)],
+    )
+    def test_simtk_to_pint(self, simtk_quantity, pint_quantity):
+        """Test conversion from SimTK Quantity to pint Quantity."""
+        converted_pint_quantity = from_simtk(simtk_quantity)
+
+        assert pint_quantity == converted_pint_quantity
+
+    @skip_if_missing("simtk.unit")
+    @pytest.mark.parametrize(
+        "simtk_unit_,unit_str",
+        [
+            (simtk_unit.kilojoule_per_mole, "mole**-1 * kilojoule"),
+            (
+                simtk_unit.kilocalories_per_mole / simtk_unit.angstrom ** 2,
+                "angstrom**-2 * mole**-1 * kilocalorie",
+            ),
+            (
+                simtk_unit.joule / (simtk_unit.mole * simtk_unit.nanometer ** 2),
+                "nanometer**-2 * mole**-1 * joule",
+            ),
+            (
+                simtk_unit.picosecond ** (-1),
+                "picosecond**-1",
+            ),
+            (simtk_unit.dimensionless, "dimensionless"),
+            (simtk_unit.second, "second"),
+            (simtk_unit.angstrom, "angstrom"),
+        ],
+    )
+    def test_simtk_unit_string_roundtrip(self, simtk_unit_, unit_str):
+        assert simtk_unit_to_string(simtk_unit_) == unit_str
+
+        assert unit_str == simtk_unit_to_string(string_to_simtk_unit(unit_str))
+
+    @pytest.mark.parametrize(
+        "openff_quantity,simtk_quantity",
+        [
+            (300.0 * unit.kelvin, 300.0 * simtk_unit.kelvin),
+            (
+                1.5 * unit.kilojoule,
+                1.5 * simtk_unit.kilojoule,
+            ),
+            (1.0 / unit.meter, 1.0 / simtk_unit.meter),
+        ],
+    )
+    def test_simtk_roundtrip(self, openff_quantity, simtk_quantity):
+        assert simtk_quantity == to_simtk(openff_quantity)
+        assert openff_quantity == from_simtk(simtk_quantity)
+
+        assert openff_quantity == from_simtk(to_simtk(openff_quantity))

--- a/openff/units/tests/test_units.py
+++ b/openff/units/tests/test_units.py
@@ -1,33 +1,8 @@
 import pickle
 
-import pytest
 from openff.utilities.testing import skip_if_missing
-from openff.utilities.utilities import has_package
 
 from openff.units import unit
-from openff.units.simtk import from_simtk
-
-if has_package("simtk.unit"):
-    from simtk import unit as simtk_unit
-
-    simtk_quantitites = [
-        4.0 * simtk_unit.nanometer,
-        5.0 * simtk_unit.angstrom,
-        1.0 * simtk_unit.elementary_charge,
-        0.5 * simtk_unit.erg,
-        1.0 * simtk_unit.dimensionless,
-    ]
-
-    pint_quantities = [
-        4.0 * unit.nanometer,
-        5.0 * unit.angstrom,
-        1.0 * unit.elementary_charge,
-        0.5 * unit.erg,
-        1.0 * unit.dimensionless,
-    ]
-else:
-    simtk_quantitites = []
-    pint_quantities = []
 
 
 class TestPickle:
@@ -57,15 +32,3 @@ class TestPickle:
         y = pickle.loads(pickle.dumps(x))
 
         assert x.value == y.value and x.error == y.error
-
-
-@skip_if_missing("simtk.unit")
-@pytest.mark.parametrize(
-    "simtk_quantity,pint_quantity",
-    [(s, p) for s, p in zip(simtk_quantitites, pint_quantities)],
-)
-def test_simtk_to_pint(simtk_quantity, pint_quantity):
-    """Test conversion from SimTK Quantity to pint Quantity."""
-    converted_pint_quantity = from_simtk(simtk_quantity)
-
-    assert pint_quantity == converted_pint_quantity


### PR DESCRIPTION
## Description
This PR ports over functionality from the [toolkit](https://github.com/openforcefield/openff-toolkit/blob/0.9.2/openff/toolkit/utils/utils.py) in an effort to get some amount of interoperability with `simtk.unit`

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go