### PR TITLE
Updates for OpenMM 7.6

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -12,6 +12,11 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-  - mypy
   - uncertainties
   - openmm
+
+    # Typing
+  - mypy
+  - typing-extensions
+  - types-setuptools
+  - types-pkg_resources

--- a/openff/units/tests/test_openmm.py
+++ b/openff/units/tests/test_openmm.py
@@ -1,0 +1,110 @@
+import pytest
+from openff.utilities.testing import skip_if_missing
+from openff.utilities.utilities import has_package
+
+from openff.units import unit
+from openff.units.openmm import from_openmm
+
+if has_package("openmm.unit"):
+    from openmm import unit as openmm_unit
+
+    from openff.units.openmm import (
+        openmm_unit_to_string,
+        string_to_openmm_unit,
+        to_openmm,
+    )
+
+    openmm_quantitites = [
+        4.0 * openmm_unit.nanometer,
+        5.0 * openmm_unit.angstrom,
+        1.0 * openmm_unit.elementary_charge,
+        0.5 * openmm_unit.erg,
+        1.0 * openmm_unit.dimensionless,
+    ]
+
+    pint_quantities = [
+        4.0 * unit.nanometer,
+        5.0 * unit.angstrom,
+        1.0 * unit.elementary_charge,
+        0.5 * unit.erg,
+        1.0 * unit.dimensionless,
+    ]
+else:
+    # Must be defined as something, despite not being used, because pytest
+    # inspect the contents of pytest.mark.parametrize during collection;
+    # otherwise NameErrors will be raised. Finding a way to skip _collection_
+    # would be more elegant than mocking a module
+    class openmm_unit:  # type: ignore[no-redef]
+        kilojoule = 1
+        kilojoule_per_mole = 1
+        kilocalories_per_mole = 1
+        angstrom = 1
+        nanometer = 1
+        meter = 1
+        picosecond = 1
+        joule = 1
+        mole = 1
+        dimensionless = 1
+        second = 1
+        kelvin = 1
+
+    openmm_quantitites = []
+    pint_quantities = []
+
+
+@pytest.mark.xfail
+@skip_if_missing("openmm.unit")
+class TestOpenMMUnits:
+    @pytest.mark.parametrize(
+        "openmm_quantity,pint_quantity",
+        [(s, p) for s, p in zip(openmm_quantitites, pint_quantities)],
+    )
+    def test_openmm_to_pint(self, openmm_quantity, pint_quantity):
+        """Test conversion from OpenMM Quantity to pint Quantity."""
+        converted_pint_quantity = from_openmm(openmm_quantity)
+
+        assert pint_quantity == converted_pint_quantity
+
+    @skip_if_missing("openmm.unit")
+    @pytest.mark.parametrize(
+        "openmm_unit_,unit_str",
+        [
+            (openmm_unit.kilojoule_per_mole, "mole**-1 * kilojoule"),
+            (
+                openmm_unit.kilocalories_per_mole / openmm_unit.angstrom ** 2,
+                "angstrom**-2 * mole**-1 * kilocalorie",
+            ),
+            (
+                openmm_unit.joule / (openmm_unit.mole * openmm_unit.nanometer ** 2),
+                "nanometer**-2 * mole**-1 * joule",
+            ),
+            (
+                openmm_unit.picosecond ** (-1),
+                "picosecond**-1",
+            ),
+            (openmm_unit.dimensionless, "dimensionless"),
+            (openmm_unit.second, "second"),
+            (openmm_unit.angstrom, "angstrom"),
+        ],
+    )
+    def test_openmm_unit_string_roundtrip(self, openmm_unit_, unit_str):
+        assert openmm_unit_to_string(openmm_unit_) == unit_str
+
+        assert unit_str == openmm_unit_to_string(string_to_openmm_unit(unit_str))
+
+    @pytest.mark.parametrize(
+        "openff_quantity,openmm_quantity",
+        [
+            (300.0 * unit.kelvin, 300.0 * openmm_unit.kelvin),
+            (
+                1.5 * unit.kilojoule,
+                1.5 * openmm_unit.kilojoule,
+            ),
+            (1.0 / unit.meter, 1.0 / openmm_unit.meter),
+        ],
+    )
+    def test_openmm_roundtrip(self, openff_quantity, openmm_quantity):
+        assert openmm_quantity == to_openmm(openff_quantity)
+        assert openff_quantity == from_openmm(openmm_quantity)
+
+        assert openff_quantity == from_openmm(to_openmm(openff_quantity))

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,5 @@ ignore_missing_imports = True
 [mypy-simtk]
 ignore_missing_imports = True
 
+[mypy-openmm]
+ignore_missing_imports = True


### PR DESCRIPTION
I took a stab at updating the import paths for OpenMM 7.6. Since "SimTK" branding is being scrubbed, and since I'd like to separate any imports from the deprecated `simtk` namespace, I made a new module `openff/units/openmm.py` that roughly tracks the existing `openff/units/simtk.py`. I made an effort to make this backwards-compatible with a warning and not break existing code.

 Locally this works as I intend for both namespaces:

```
$ python
Python 3.9.0 | packaged by conda-forge | (default, Nov 26 2020, 07:54:06)
[Clang 11.0.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from openmm import unit
val >>> val = u
KeyboardInterrupt
>>> from openmm import unit
>>> val = 4 * unit.nanometer
>>> from openff.units.openmm import from_openmm
>>> from_openmm(val)
<Quantity(4, 'nanometer')>
>>> type(from_openmm(val))
<class 'openff.units.units.Quantity'>
>>> from openff.units.simtk import from_simtk
>>> from_simtk(val)
<Quantity(4, 'nanometer')>
>>> type(from_simtk(val))
<class 'openff.units.units.Quantity'>
>>> from_openmm(val) == from_simtk(val)
True
>>>
$ mamba install "openmm ==7.5" -c conda-forge -yq                                                                                              openmm  ✱
  Package   Version  Build                   Channel                  Size
────────────────────────────────────────────────────────────────────────────
  Downgrade:
────────────────────────────────────────────────────────────────────────────

  - openmm    7.6.0  py39h8d72adf_0_khronos  installed
  + openmm    7.5.0  py39h7e6e922_6_khronos  conda-forge/osx-64     Cached

  Summary:

  Downgrade: 1 packages

  Total download: 0  B

────────────────────────────────────────────────────────────────────────────

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
$ python
Python 3.9.0 | packaged by conda-forge | (default, Nov 26 2020, 07:54:06)
[Clang 11.0.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from simtk import unit
>>> val = 4 * unit.nanometer
>>> from openff.units.simtk import from_simtk
/Users/mwt/software/openff-units/openff/units/simtk.py:36: UserWarning: The openff.units.simtk module is deprecated. Use openff.units.openmm instead.
  warnings.warn(
>>> from_simtk(val)
<Quantity(4, 'nanometer')>
>>> type(from_simtk(val))
<class 'openff.units.units.Quantity'>
>>>
```