### PR TITLE
added timestep unit

### DIFF
--- a/openff/units/data/defaults.txt
+++ b/openff/units/data/defaults.txt
@@ -90,6 +90,9 @@ week = 7 * day
 year = 365.25 * day = a = yr = julian_year
 month = year / 12
 
+# MD Time
+timestep = [timestep] = _ = timesteps
+
 # Temperature
 degree_Celsius = kelvin; offset: 273.15 = °C = celsius = degC = degreeC
 

--- a/openff/units/tests/test_units.py
+++ b/openff/units/tests/test_units.py
@@ -61,3 +61,16 @@ class TestCompChemUnits:
     )
     def test_parse_molar_units_string(self, shorthand_string, full_string):
         assert unit.Quantity(shorthand_string) == unit.Quantity(full_string)
+
+    def test_timestep_creation(self):
+        # basic sanity check, can I make the unit and does it serialize
+        q = 10 * unit.timestep
+
+        assert q.m == 10
+        assert str(q) == '10 timestep'
+
+    def test_timestep_compatibility(self):
+        # timesteps aren't a form of time
+        q = 20 * unit.timestep
+
+        assert not q.is_compatible_with(10 * unit.picosecond)


### PR DESCRIPTION
## Description

To try and avoid confusion between timesteps (i.e. discrete integrations) and time (e.g. ps) when e.g. setting a thermostat relaxation I added timestep.  This isn't in openmm, but I think we'll want it for our schema, it might make sense to kick it upstream to here.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go