### PR TITLE
Support converting units representing constants to OpenMM

### DIFF
--- a/openff/units/openmm.py
+++ b/openff/units/openmm.py
@@ -95,7 +95,10 @@ def _ast_eval(node):
         return operators[type(node.op)](_ast_eval(node.operand))
     elif isinstance(node, ast.Name):
         # see if this is a openmm unit
-        b = getattr(openmm_unit, node.id)
+        try:
+            b = getattr(openmm_unit, node.id)
+        except AttributeError:
+            raise MissingOpenMMUnitError(node.id)
         return b
     # TODO: This toolkit code that had a hack to cover some edge behavior; not clear which tests trigger it
     elif isinstance(node, ast.List):
@@ -160,10 +163,7 @@ def to_openmm(quantity: Quantity) -> "openmm_unit.Quantity":
 
         unit_string = str(quantity.units._units)
 
-        try:
-            openmm_unit_ = string_to_openmm_unit(unit_string)
-        except AttributeError:
-            raise MissingOpenMMUnitError(unit_string)
+        openmm_unit_ = string_to_openmm_unit(unit_string)
 
         return value * openmm_unit_
 

--- a/openff/units/simtk.py
+++ b/openff/units/simtk.py
@@ -118,7 +118,10 @@ def _ast_eval(node):
         return operators[type(node.op)](_ast_eval(node.operand))
     elif isinstance(node, ast.Name):
         # see if this is a simtk unit
-        b = getattr(simtk_unit, node.id)
+        try:
+            b = getattr(simtk_unit, node.id)
+        except AttributeError:
+            raise MissingOpenMMUnitError(node.id)
         return b
     # TODO: This toolkit code that had a hack to cover some edge behavior; not clear which tests trigger it
     elif isinstance(node, ast.List):
@@ -170,11 +173,7 @@ def to_simtk(quantity) -> "simtk_unit.Quantity":
         value = quantity.m
 
         unit_string = str(quantity.units._units)
-
-        try:
-            simtk_unit_ = string_to_simtk_unit(unit_string)
-        except AttributeError:
-            raise MissingOpenMMUnitError(unit_string)
+        simtk_unit_ = string_to_simtk_unit(unit_string)
 
         return value * simtk_unit_
 

--- a/openff/units/tests/test_openmm.py
+++ b/openff/units/tests/test_openmm.py
@@ -14,13 +14,14 @@ if has_package("openmm.unit"):
         to_openmm,
     )
 
-    openmm_quantitites = [
+    openmm_quantities = [
         4.0 * openmm_unit.nanometer,
         5.0 * openmm_unit.angstrom,
         1.0 * openmm_unit.elementary_charge,
         0.5 * openmm_unit.erg,
         1.0 * openmm_unit.dimensionless,
         0.5 * openmm_unit.dalton,
+        0.008314462621026537 * openmm.nanometer ** 2 openmm_unit.dalton / openmm.kelvin / openmm.picosecond ** 2,
     ]
 
     pint_quantities = [
@@ -30,6 +31,7 @@ if has_package("openmm.unit"):
         0.5 * unit.erg,
         1.0 * unit.dimensionless,
         0.5 * unit.gram / unit.mol,
+        1.0 * unit.boltzmann_constant,
     ]
 else:
     # Must be defined as something, despite not being used, because pytest
@@ -50,7 +52,7 @@ else:
         second = 1
         kelvin = 1
 
-    openmm_quantitites = []
+    openmm_quantities = []
     pint_quantities = []
 
 
@@ -58,13 +60,23 @@ else:
 class TestOpenMMUnits:
     @pytest.mark.parametrize(
         "openmm_quantity,pint_quantity",
-        [(s, p) for s, p in zip(openmm_quantitites, pint_quantities)],
+        [(s, p) for s, p in zip(openmm_quantities, pint_quantities)],
     )
     def test_openmm_to_pint(self, openmm_quantity, pint_quantity):
         """Test conversion from OpenMM Quantity to pint Quantity."""
         converted_pint_quantity = from_openmm(openmm_quantity)
 
         assert pint_quantity == converted_pint_quantity
+
+    @pytest.mark.parametrize(
+        "openmm_quantity,pint_quantity",
+        [(s, p) for s, p in zip(openmm_quantities, pint_quantities)],
+    )
+    def test_pint_to_openmm(self, openmm_quantity, pint_quantity):
+        """Test conversion from OpenMM Quantity to pint Quantity."""
+        converted_openmm_quantity = to_openmm(pint_quantity)
+
+        assert abs(openmm_quantity - converted_openmm_quantity) < 1.0e-5
 
     @skip_if_missing("openmm.unit")
     @pytest.mark.parametrize(

--- a/openff/units/tests/test_openmm.py
+++ b/openff/units/tests/test_openmm.py
@@ -21,7 +21,11 @@ if has_package("openmm.unit"):
         0.5 * openmm_unit.erg,
         1.0 * openmm_unit.dimensionless,
         0.5 * openmm_unit.dalton,
-        0.008314462621026537 * openmm.nanometer ** 2 openmm_unit.dalton / openmm.kelvin / openmm.picosecond ** 2,
+        0.008314462621026537
+        * openmm_unit.nanometer**2
+        * openmm_unit.dalton
+        / openmm_unit.kelvin
+        / openmm_unit.picosecond**2,
     ]
 
     pint_quantities = [

--- a/openff/units/tests/test_simtk.py
+++ b/openff/units/tests/test_simtk.py
@@ -17,6 +17,11 @@ if has_package("simtk.unit"):
         0.5 * simtk_unit.erg,
         1.0 * simtk_unit.dimensionless,
         0.5 * simtk_unit.dalton,
+        0.008314462621026537
+        * simtk_unit.nanometer**2
+        * simtk_unit.dalton
+        / simtk_unit.kelvin
+        / simtk_unit.picosecond**2,
     ]
 
     pint_quantities = [
@@ -26,6 +31,7 @@ if has_package("simtk.unit"):
         0.5 * unit.erg,
         1.0 * unit.dimensionless,
         0.5 * unit.gram / unit.mol,
+        1.0 * unit.boltzmann_constant,
     ]
 else:
     simtk_quantitites = []
@@ -43,6 +49,16 @@ class TestSimTKUnits:
         converted_pint_quantity = from_simtk(simtk_quantity)
 
         assert pint_quantity == converted_pint_quantity
+
+    @pytest.mark.parametrize(
+        "simtk_quantity,pint_quantity",
+        [(s, p) for s, p in zip(simtk_quantitites, pint_quantities)],
+    )
+    def test_pint_to_simtk(self, converted_simtk_quantity, pint_quantity):
+        """Test conversion from SimTK Quantity to pint Quantity."""
+        converted_simtk_quantity = to_simtk(pint_quantity)
+
+        assert abs(converted_simtk_quantity - converted_simtk_quantity) < 1.0e-5
 
     @skip_if_missing("simtk.unit")
     @pytest.mark.parametrize(

--- a/openff/units/utilities.py
+++ b/openff/units/utilities.py
@@ -16,3 +16,5 @@ def get_defaults_path() -> str:
 
 class MissingOpenMMUnitError(Exception):
     """OpenMM doesn't know this unit"""
+
+    pass

--- a/openff/units/utilities.py
+++ b/openff/units/utilities.py
@@ -12,3 +12,7 @@ __all__ = [
 def get_defaults_path() -> str:
     """Get the full path to the ``defaults.txt`` file"""
     return get_data_file_path("defaults.txt", "openff.units")
+
+
+class MissingOpenMMUnitError(Exception):
+    """OpenMM doesn't know this unit"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ omit =
 
 [flake8]
 max-line-length = 119
-ignore = E203
+ignore = E203,W503
 
 [isort]
 multi_line_output=3


### PR DESCRIPTION
## Description
Closes #29. I'll write up more detailed docs if this strategy is deemed appropriate!

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] `Unit.get_compatible_md_units()` method, which gets nm/da/ps/e units with the same dimensions as self
  - [x] `Quantity.to_md_units()` and `Quantity.ito_md_units()` methods that convert a quantity to the compatible MD units
  - [x] Call `Quantity.to_md_units()` if a unit fails to convert to OpenMM units
  - [x] Tests
  - [x] Basic docs
  - [ ] Detailed docs

## Questions
- [ ] Do we like it?

## Status
- [ ] Ready to go