### PR TITLE
Drop Python 3.7 in tests and pin Pint to 0.19.0+

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,8 @@ jobs:
       matrix:
         os: [macOS-latest, ubuntu-latest]
         openmm: ["true", "false"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         exclude:
-          # As of March 2021, these conda builds are broken and unavailable
           - openmm: "true"
             python-version: "3.10"
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python
   - pip
   - numpy
-  - pint >=0.16.1
+  - pint >=0.19.0
   - openff-utilities >=0.1.3
 
     # Tests
@@ -17,4 +17,3 @@ dependencies:
 
     # Typing
   - mypy
-  - typing-extensions


### PR DESCRIPTION
Python 3.7 is long gone according to [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). This PR removes it from CI.

This also enabled me to pin `pint >=0.19.0`, which partially addresses a part of #27 