### PR TITLE
Have `to_openmm` convert to base units if conversion would otherwise fail

### DIFF
--- a/openff/units/exceptions.py
+++ b/openff/units/exceptions.py
@@ -1,0 +1,4 @@
+class MissingOpenMMUnitError(Exception):
+    """OpenMM doesn't know this unit"""
+
+    pass

--- a/openff/units/exceptions.py
+++ b/openff/units/exceptions.py
@@ -1,4 +1,4 @@
 class MissingOpenMMUnitError(Exception):
-    """OpenMM doesn't know this unit"""
+    """Raised when a unit cannot be converted to an equivalent OpenMM unit"""
 
     pass

--- a/openff/units/openmm.py
+++ b/openff/units/openmm.py
@@ -75,6 +75,11 @@ def _ast_eval(node):
     Parameters
     ----------
     node : An ast parsing tree node
+
+    Raises
+    ------
+    openff.units.exceptions.MissingOpenMMUnitError
+        if the unit is unavailable in OpenMM.
     """
 
     operators = {
@@ -122,6 +127,11 @@ def string_to_openmm_unit(unit_string: str) -> "openmm_unit.Unit":
     -------
     output_unit: openmm.unit.Quantity
         The deserialized unit from the string
+
+    Raises
+    ------
+    openff.units.exceptions.MissingOpenMMUnitError
+        if the unit is unavailable in OpenMM.
     """
     if unit_string == "standard_atmosphere":
         return openmm_unit.atmosphere
@@ -155,7 +165,11 @@ def to_openmm(quantity: Quantity) -> "openmm_unit.Quantity":
 
     :class:`openmm.unit.quantity.Quantity` from OpenMM and
     :class:`openff.units.Quantity` from this package both represent a numerical
-    value with units.
+    value with units. The units available in the two packages differ; when a
+    unit is missing from the target package, the resulting quantity will be in
+    base units (kg/m/s/A/K/mole), which are shared between both packages. This
+    may cause the resulting value to be slightly different to the input due to
+    the limited precision of floating point numbers.
     """
 
     def to_openmm_inner(quantity) -> "openmm_unit.Quantity":

--- a/openff/units/openmm.py
+++ b/openff/units/openmm.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING, List
 from openff.utilities import has_package, requires_package
 
 from openff.units import unit
-from openff.units.units import Quantity
 from openff.units.exceptions import MissingOpenMMUnitError
+from openff.units.units import Quantity
 
 __all__ = [
     "from_openmm",

--- a/openff/units/simtk.py
+++ b/openff/units/simtk.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, List
 from openff.utilities import has_package, requires_package
 
 from openff.units import unit
+from openff.units.exceptions import MissingOpenMMUnitError
 
 __all__ = [
     "from_simtk",
@@ -117,7 +118,10 @@ def _ast_eval(node):
         return operators[type(node.op)](_ast_eval(node.operand))
     elif isinstance(node, ast.Name):
         # see if this is a simtk unit
-        b = getattr(simtk_unit, node.id)
+        try:
+            b = getattr(simtk_unit, node.id)
+        except AttributeError:
+            raise MissingOpenMMUnitError(node.id)
         return b
     # TODO: This toolkit code that had a hack to cover some edge behavior; not clear which tests trigger it
     elif isinstance(node, ast.List):
@@ -164,9 +168,16 @@ def from_simtk(simtk_quantity: "simtk_unit.Quantity"):
 @requires_package("simtk.unit")
 def to_simtk(quantity) -> "simtk_unit.Quantity":
     """Convert an OpenFF ``Quantity`` to an OpenMM ``Quantity`` from the ``simtk`` namespace"""
-    value = quantity.m
 
-    unit_string = str(quantity.units._units)
-    simtk_unit_ = string_to_simtk_unit(unit_string)
+    def to_simtk_inner(quantity) -> "simtk_unit.Quantity":
+        value = quantity.m
 
-    return value * simtk_unit_
+        unit_string = str(quantity.units._units)
+        simtk_unit_ = string_to_simtk_unit(unit_string)
+
+        return value * simtk_unit_
+
+    try:
+        return to_simtk_inner(quantity)
+    except MissingOpenMMUnitError:
+        return to_simtk_inner(quantity.to_base_units())

--- a/openff/units/simtk.py
+++ b/openff/units/simtk.py
@@ -98,6 +98,11 @@ def _ast_eval(node):
     Parameters
     ----------
     node : An ast parsing tree node
+
+    Raises
+    ------
+    Raises :exception:`openff.units.exceptions.MissingOpenMMUnitError` if the unit
+    is unavailable in SimTK.
     """
 
     operators = {
@@ -132,8 +137,8 @@ def _ast_eval(node):
 
 def string_to_simtk_unit(unit_string: str) -> "simtk_unit.Quantity":
     """
-    Deserializes a simtk.unit.Quantity from a string representation, for
-    example: "kilocalories_per_mole / angstrom ** 2"
+    Deserializes a :class:`simtk.unit.Quantity` from a string representation, for
+    example: ``"kilocalories_per_mole / angstrom ** 2"``
 
 
     Parameters
@@ -145,6 +150,11 @@ def string_to_simtk_unit(unit_string: str) -> "simtk_unit.Quantity":
     -------
     output_unit: simtk.unit.Quantity
         The deserialized unit from the string
+
+    Raises
+    ------
+    openff.units.exceptions.MissingOpenMMUnitError
+        if the unit is unavailable in SimTK.
     """
 
     output_unit = _ast_eval(ast.parse(unit_string, mode="eval").body)  # type: ignore
@@ -167,7 +177,15 @@ def from_simtk(simtk_quantity: "simtk_unit.Quantity"):
 
 @requires_package("simtk.unit")
 def to_simtk(quantity) -> "simtk_unit.Quantity":
-    """Convert an OpenFF ``Quantity`` to an OpenMM ``Quantity`` from the ``simtk`` namespace"""
+    """Convert an OpenFF ``Quantity`` to an SimTK ``Quantity``
+
+    :class:`simtk.unit.quantity.Quantity` from SimTK and
+    :class:`openff.units.Quantity` from this package both represent a numerical
+    value with units. The units available in the two packages differ; when a
+    unit is missing from the target package, the resulting quantity will be in
+    base units (kg/m/s/A/K/mole), which are shared between both packages. This
+    may cause the resulting value to be slightly different to the input due to
+    the limited precision of floating point numbers."""
 
     def to_simtk_inner(quantity) -> "simtk_unit.Quantity":
         value = quantity.m

--- a/openff/units/tests/test_openmm.py
+++ b/openff/units/tests/test_openmm.py
@@ -3,7 +3,7 @@ from openff.utilities.testing import skip_if_missing
 from openff.utilities.utilities import has_package
 
 from openff.units import unit
-from openff.units.openmm import from_openmm, to_openmm
+from openff.units.openmm import from_openmm
 
 if has_package("openmm.unit"):
     from openmm import unit as openmm_unit

--- a/openff/units/tests/test_simtk.py
+++ b/openff/units/tests/test_simtk.py
@@ -3,7 +3,7 @@ from openff.utilities.testing import skip_if_missing
 from openff.utilities.utilities import has_package
 
 from openff.units import unit
-from openff.units.simtk import from_simtk, to_simtk
+from openff.units.simtk import from_simtk
 
 if has_package("simtk.unit"):
     from simtk import unit as simtk_unit

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ omit =
 
 [flake8]
 max-line-length = 119
-ignore = E203
+ignore = E203,W503
 
 [isort]
 multi_line_output=3


### PR DESCRIPTION
## Description
Supersedes #30, closes #29

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Call `to_base_units` on quantities that cannot be directly converted to OpenMM units
  - [x] Tests for the above behaviour and possible regressions for other units
  - [x] Support black's formatting in flake8 tests
  - [x] Documentation

## Questions
None so far

## Status
- [x] Ready to go