### PR TITLE
Add `Quantity.to_openmm`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,6 +96,8 @@ python_use_unqualified_type_names = True
 napoleon_google_docstring = True
 napoleon_use_param = False
 napoleon_use_ivar = True
+napoleon_use_rtype = False
+napoleon_preprocess_types = True
 
 myst_enable_extensions = [
     "deflist",

--- a/openff/units/tests/test_units.py
+++ b/openff/units/tests/test_units.py
@@ -6,6 +6,21 @@ from openff.utilities.testing import skip_if_missing
 from openff.units import unit
 
 
+class TestQuantity:
+    @skip_if_missing("openmm.unit")
+    def test_to_openmm_method(self):
+        """
+        Test the basic behavior of `Quantity.to_openmm` as an API call. Testing of the underlying
+        behavior of the standalone `to_openmm` function is in opeff/units/tests/test_openmm.py.
+        """
+        from openmm import unit as openmm_unit
+
+        quantity = unit.Quantity(0.5, "nanometer")
+        converted = quantity.to_openmm()
+
+        assert converted == openmm_unit.Quantity(0.5, openmm_unit.nanometer)
+
+
 class TestPickle:
     """Test pickle-based serialization of Quantity, Unit, and Measurement objects
 

--- a/openff/units/units.py
+++ b/openff/units/units.py
@@ -4,13 +4,18 @@ Core classes for OpenFF Units
 
 import uuid
 import warnings
+from typing import TYPE_CHECKING
 
 import pint
+from openff.utilities import requires_package
 from pint.measurement import _Measurement
 from pint.quantity import _Quantity
 from pint.unit import _Unit
 
 from openff.units.utilities import get_defaults_path
+
+if TYPE_CHECKING:
+    from openmm.unit import Quantity as OpenMMQuantity
 
 __all__ = [
     "DEFAULT_UNIT_REGISTRY",
@@ -62,6 +67,19 @@ class Quantity(_Quantity):
     def _dask_finalize(results, func, args, units):
         values = func(results, *args)
         return Quantity(values, units)
+
+    @requires_package("openmm")
+    def to_openmm(self) -> "OpenMMQuantity":
+        """Convert the quantity to an `openmm.unit.Quantity`.
+
+        Returns
+        -------
+        openmm_unit : str
+            The OpenMM compatible unit.
+        """
+        from openff.units.openmm import to_openmm
+
+        return to_openmm(self)
 
 
 class Measurement(_Measurement):

--- a/openff/units/units.py
+++ b/openff/units/units.py
@@ -70,12 +70,12 @@ class Quantity(_Quantity):
 
     @requires_package("openmm")
     def to_openmm(self) -> "OpenMMQuantity":
-        """Convert the quantity to an `openmm.unit.Quantity`.
+        """Convert the quantity to an ``openmm.unit.Quantity``.
 
         Returns
         -------
-        openmm_unit : str
-            The OpenMM compatible unit.
+        openmm_quantity : openmm.unit.quantity.Quantity
+            The OpenMM compatible quantity.
         """
         from openff.units.openmm import to_openmm
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,5 +50,8 @@ ignore_missing_imports = True
 [mypy-openmm]
 ignore_missing_imports = True
 
+[mypy-openmm.unit]
+ignore_missing_imports = True
+
 [mypy-openmm.app.element]
 ignore_missing_imports = True


### PR DESCRIPTION
This implements idea # 1 of #27

@Yoshanuikabundi is this what you had in mind? I went with the simplest implementation I could think of and checks all of the boxes I had in mind:
- [x] Adds `Quantity.to_openmm` function to save users an import
  - [x] Just calls existing code (i.e. adds no unneeded complexity, does not require extensive new tests)
- [x] Does not obviously create a circular import issue
- [x] Does not introduce a hard OpenMM dependency
- [x] Just kinda works?

```python3
>>> from openff.units import unit
>>> x = unit.Quantity(1, "meter")
>>> x
<Quantity(1, 'meter')>
>>> x.to_openmm()
Quantity(value=1, unit=meter)