### PR TITLE
QoL improvements for IDEs and LSPs

### DIFF
--- a/openff/units/exceptions.py
+++ b/openff/units/exceptions.py
@@ -1,3 +1,10 @@
+__all__ = [
+    "MissingOpenMMUnitError",
+    "NoneQuantityError",
+    "NoneUnitError",
+]
+
+
 class MissingOpenMMUnitError(Exception):
     """Raised when a unit cannot be converted to an equivalent OpenMM unit"""
 

--- a/openff/units/units.py
+++ b/openff/units/units.py
@@ -4,7 +4,7 @@ Core classes for OpenFF Units
 
 import uuid
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import pint
 from openff.utilities import requires_package
@@ -52,7 +52,10 @@ class Unit(_Unit):
         return _unpickle_unit, (Unit, self._units)
 
 
-class Quantity(_Quantity):
+_MagnitudeType = TypeVar("_MagnitudeType")
+
+
+class Quantity(_Quantity[_MagnitudeType]):
     """A value with associated units."""
 
     _REGISTRY = DEFAULT_UNIT_REGISTRY


### PR DESCRIPTION
## Description
I ran into a few minor barbs working with units in the Toolkit using the [PyRight](https://github.com/microsoft/pyright) LSP. PyRight includes a type checker that is generally stricter than MyPy and less pedantic than `MyPy --strict`, so I love it. This PR fixes those barbs.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add `__all__` to the exceptions module.
      - This helps IDEs understand that the exceptions are part of the public API.
  - [x] Make `Quantity` generic over its magnitude type. 
      - This allows users to specify the magnitude type as part of a type annotation, which is very useful. Previously, an OpenFF `Quantity` was always a `Quantity[Any]`.
      - MyPy seems to be fine with specifying a generic for a non-generic type, but Python itself is not (it causes a TypeError).

## Status
- [x] Ready to go