### PR TITLE
Add `ensure_quantity` helper function

### DIFF
--- a/openff/units/openmm.py
+++ b/openff/units/openmm.py
@@ -1,7 +1,6 @@
 """
 Functions for converting between OpenFF and OpenMM units
 """
-
 import ast
 import operator as op
 from typing import TYPE_CHECKING, List, Literal, Union
@@ -235,9 +234,13 @@ def ensure_quantity(
     unknown_quantity: Union[Quantity, "openmm_unit.Quantity"],
     type_to_ensure: Literal["openmm", "openff"],
 ) -> Union[Quantity, "openmm_unit.Quantity"]:
+    type_to_ensure = type_to_ensure.lower()
     if type_to_ensure == "openmm":
         return _ensure_openmm_quantity(unknown_quantity)
     elif type_to_ensure == "openff":
         return _ensure_openff_quantity(unknown_quantity)
     else:
-        raise Exception
+        raise ValueError(
+            f"Unsupported `type_to_ensure` found. Given {type_to_ensure}, "
+            "expected 'openff' or 'openmm'."
+        )

--- a/openff/units/openmm.py
+++ b/openff/units/openmm.py
@@ -234,7 +234,6 @@ def ensure_quantity(
     unknown_quantity: Union[Quantity, "openmm_unit.Quantity"],
     type_to_ensure: Literal["openmm", "openff"],
 ) -> Union[Quantity, "openmm_unit.Quantity"]:
-    type_to_ensure = type_to_ensure.lower()
     if type_to_ensure == "openmm":
         return _ensure_openmm_quantity(unknown_quantity)
     elif type_to_ensure == "openff":

--- a/openff/units/tests/test_openmm.py
+++ b/openff/units/tests/test_openmm.py
@@ -194,6 +194,12 @@ class TestEnsureType:
 
         assert ensure_quantity(x, registry) == ensure_quantity(y, registry)
 
+    def test_unsupported_type(self):
+        x = unit.Quantity(4.0, unit.angstrom)
+
+        with pytest.raises(ValueError, match="Unsupported.*type_to_ensure.*pint"):
+            ensure_quantity(x, "pint")
+
     def test_short_circuit(self):
         x = unit.Quantity(4.0, unit.angstrom)
         y = openmm_unit.Quantity(4.0, openmm_unit.angstrom)

--- a/openff/units/tests/test_openmm.py
+++ b/openff/units/tests/test_openmm.py
@@ -4,7 +4,7 @@ from openff.utilities.utilities import has_package
 
 from openff.units import unit
 from openff.units.exceptions import NoneQuantityError, NoneUnitError
-from openff.units.openmm import from_openmm
+from openff.units.openmm import ensure_quantity, from_openmm
 
 if has_package("openmm.unit"):
     from openmm import unit as openmm_unit
@@ -176,3 +176,27 @@ class TestOpenMMUnits:
             * to_openmm_quantity
             * openmm_unit.dimensionless
         )
+
+
+@skip_if_missing("openmm.unit")
+class TestEnsureType:
+    from openmm import unit as openmm_unit
+
+    from openff.units import unit
+
+    @pytest.mark.parametrize(
+        "registry",
+        ["openmm", "openff"],
+    )
+    def test_ensure_units(self, registry):
+        x = unit.Quantity(4.0, unit.angstrom)
+        y = openmm_unit.Quantity(4.0, openmm_unit.angstrom)
+
+        assert ensure_quantity(x, registry) == ensure_quantity(y, registry)
+
+    def test_short_circuit(self):
+        x = unit.Quantity(4.0, unit.angstrom)
+        y = openmm_unit.Quantity(4.0, openmm_unit.angstrom)
+
+        assert id(ensure_quantity(x, "openff")) == id(x)
+        assert id(ensure_quantity(y, "openmm")) == id(y)


### PR DESCRIPTION
A frequent source of source of grief suffered by users and developers is switching between `Quantity` objects offered by OpenMM vs. this project vs. other sources. The `to_openmm` and `from_openmm` functions help, but they could be made more accessible - they shift the burden of checking the type onto the user or developer. This sounds trivial, but it adds unnecessary copy+paste cruft into packages and can disrupt the flow of a scientist doing actual work in a notebook. This PR adds a brute-force function `ensure_quantity` that takes in a quantity from either unit package and a string identifying which type it's expected to be and returns the appropriate type, either short-circuiting or doing the appropriate conversion. This might help make some type-checkers happy, and I think it _could_ reduce the chance that a wrong unit is passed around somewhere.

Does this sound useful @Yoshanuikabundi @j-wags? I'm neutral on the naming of the function or how `type_to_ensure` should be input; a string seems low-friction (i.e. compared to a boolean, since we're not sure if a third option might be allowed in the future).