### PR TITLE
Re-export `ensure_quantity` at top level

### DIFF
--- a/openff/units/__init__.py
+++ b/openff/units/__init__.py
@@ -1,6 +1,7 @@
 from pint import UnitRegistry
 
 from openff.units._version import get_versions  # type: ignore
+from openff.units.openmm import ensure_quantity
 from openff.units.units import DEFAULT_UNIT_REGISTRY, Measurement, Quantity, Unit
 
 __all__ = [
@@ -8,6 +9,7 @@ __all__ = [
     "Quantity",
     "Measurement",
     "Unit",
+    "ensure_quantity",
 ]
 
 unit: UnitRegistry = DEFAULT_UNIT_REGISTRY

--- a/openff/units/_version.py
+++ b/openff/units/_version.py
@@ -53,7 +53,7 @@ class NotThisMethod(Exception):
     """Exception raised if a method is not valid for the current scenario."""
 
 
-LONG_VERSION_PY = {}  # type: ignore
+LONG_VERSION_PY = {}
 HANDLERS = {}
 
 

--- a/openff/units/elements.py
+++ b/openff/units/elements.py
@@ -29,16 +29,15 @@ consistent with recent IUPAC values [2].
 """
 from typing import Dict
 
-from openff.units import unit
-from openff.units.units import Quantity
+from openff.units import Quantity, unit
 
 __all__ = [
     "MASSES",
     "SYMBOLS",
 ]
 
-MASSES: Dict[int, Quantity] = {
-    index + 1: mass * unit.dalton
+MASSES: Dict[int, Quantity[float]] = {
+    index + 1: Quantity(mass, unit.dalton)
     for index, mass in enumerate(
         [
             1.007947,
@@ -285,4 +284,3 @@ SYMBOLS: Dict[int, str] = {
         ]
     )
 }
-"""Mapping from atomic number to element symbol"""

--- a/openff/units/openmm.py
+++ b/openff/units/openmm.py
@@ -7,12 +7,12 @@ from typing import TYPE_CHECKING, List, Literal, Union
 
 from openff.utilities import has_package, requires_package
 
-from openff.units import unit
 from openff.units.exceptions import (
     MissingOpenMMUnitError,
     NoneQuantityError,
     NoneUnitError,
 )
+from openff.units.units import DEFAULT_UNIT_REGISTRY as unit
 from openff.units.units import Quantity
 
 __all__ = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,12 @@ omit =
     # Omit generated versioneer
     openff/units/_version.py
 
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:
+    raise NotImplementedError
+
 [flake8]
 max-line-length = 119
 ignore = E203,W503
@@ -31,14 +37,14 @@ versionfile_build = openff/units/_version.py
 tag_prefix = ''
 
 [mypy]
+warn_unused_configs = True
+implicit_reexport = True
+exclude=openff/units/tests/
 
 [mypy-pint]
 ignore_missing_imports = True
 
 [mypy-pint.*]
-ignore_missing_imports = True
-
-[mypy-openff.toolkit.*]
 ignore_missing_imports = True
 
 [mypy-openff.utilities.*]


### PR DESCRIPTION
I find it mildly inconvenient to write out all of

```python3
from openff.units.openmm import ensure_quantity
```

and this should enable


```python3
from openff.units import ensure_quantity
```