### PR TITLE
Update for Pint 0.20.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,18 +81,18 @@ jobs:
     - name: Run unit tests with OpenMM
       if: ${{ matrix.openmm == 'true' }}
       run: |
-        pytest $PYTEST_ARGS $COV openff/units/tests/
+        python -m pytest $PYTEST_ARGS $COV openff/units/tests/
 
     - name: Run unit tests without OpenMM
       if: ${{ matrix.openmm == 'false' }}
       run: |
-        pytest $PYTEST_ARGS $COV openff/units/tests/ \
+        python -m pytest $PYTEST_ARGS $COV openff/units/tests/ \
           --ignore=openff/units/tests/test_openmm.py
 
     - name: Run docexamples
       if: ${{ matrix.openmm == 'true' }}
       run: |
-        pytest --doctest-modules $PYTEST_ARGS $COV openff
+        python -m pytest --doctest-modules $PYTEST_ARGS $COV openff --ignore=openff/units/tests
 
     - name: Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,7 @@ jobs:
 
     - name: Run mypy
       if: ${{ matrix.python-version == 3.9 }}
+      continue-on-error: true
       run: |
         mypy --namespace-packages -p "openff.units"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,25 +74,24 @@ jobs:
 
     - name: Run mypy
       if: ${{ matrix.python-version == 3.9 }}
-      continue-on-error: true
       run: |
         mypy --namespace-packages -p "openff.units"
 
     - name: Run unit tests with OpenMM
       if: ${{ matrix.openmm == 'true' }}
       run: |
-        python -m pytest $PYTEST_ARGS $COV openff/units/tests/
+        pytest $PYTEST_ARGS $COV openff/units/tests/
 
     - name: Run unit tests without OpenMM
       if: ${{ matrix.openmm == 'false' }}
       run: |
-        python -m pytest $PYTEST_ARGS $COV openff/units/tests/ \
+        pytest $PYTEST_ARGS $COV openff/units/tests/ \
           --ignore=openff/units/tests/test_openmm.py
 
     - name: Run docexamples
       if: ${{ matrix.openmm == 'true' }}
       run: |
-        python -m pytest --doctest-modules $PYTEST_ARGS $COV openff --ignore=openff/units/tests
+        pytest --doctest-modules $PYTEST_ARGS $COV openff --ignore=openff/units/tests
 
     - name: Codecov
       uses: codecov/codecov-action@v1

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python
   - pip
   - numpy
-  - pint >=0.19
+  - pint >=0.20
   - openff-utilities >=0.1.3
   - sphinx >=4.5,<5
   - myst-parser>=0.13.6

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python
   - pip
   - numpy
-  - pint >=0.20
+  - pint >=0.20.1
   - openff-utilities >=0.1.3
   - sphinx >=4.5,<5
   - myst-parser>=0.13.6

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python
   - pip
   - numpy
-  - pint >=0.19.0
+  - pint >=0.20.0
   - openff-utilities >=0.1.3
 
     # Tests

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python
   - pip
   - numpy
-  - pint >=0.20.0
+  - pint >=0.20.1
   - openff-utilities >=0.1.3
 
     # Tests

--- a/openff/units/__init__.py
+++ b/openff/units/__init__.py
@@ -1,8 +1,12 @@
-from pint import UnitRegistry
-
 from openff.units._version import get_versions  # type: ignore
 from openff.units.openmm import ensure_quantity
-from openff.units.units import DEFAULT_UNIT_REGISTRY, Measurement, Quantity, Unit
+from openff.units.units import (
+    DEFAULT_UNIT_REGISTRY,
+    Measurement,
+    Quantity,
+    Unit,
+    UnitRegistry,
+)
 
 __all__ = [
     "unit",

--- a/openff/units/data/defaults.txt
+++ b/openff/units/data/defaults.txt
@@ -109,7 +109,8 @@ hertz = 1 / second = Hz
 reciprocal_centimeter = 1 / cm = cm_1 = kayser
 
 # Velocity
-[velocity] = [length] / [time] = [speed]
+# As of 0.20, derived dimensions cannot have aliases
+[velocity] = [length] / [time]
 
 # Acceleration
 [acceleration] = [velocity] / [time]

--- a/openff/units/elements.py
+++ b/openff/units/elements.py
@@ -36,7 +36,7 @@ __all__ = [
     "SYMBOLS",
 ]
 
-MASSES: Dict[int, Quantity[float]] = {
+MASSES: Dict[int, Quantity] = {
     index + 1: Quantity(mass, unit.dalton)
     for index, mass in enumerate(
         [

--- a/openff/units/openmm.py
+++ b/openff/units/openmm.py
@@ -264,7 +264,7 @@ def _ensure_openff_quantity(
             )
     else:
         try:
-            return unit.Quantity(  # type: ignore
+            return unit.Quantity(
                 unknown_quantity,
                 unit.dimensionless,
             )

--- a/openff/units/openmm.py
+++ b/openff/units/openmm.py
@@ -211,6 +211,8 @@ def to_openmm(quantity: Quantity) -> "openmm_unit.Quantity":
 
         return value * openmm_unit_
 
+    assert isinstance(quantity, Quantity)
+
     try:
         return to_openmm_inner(quantity)
     except MissingOpenMMUnitError:

--- a/openff/units/tests/test_units.py
+++ b/openff/units/tests/test_units.py
@@ -36,14 +36,14 @@ class TestPickle:
 
         assert x == y
 
-    def test_pick_quantity(self):
+    def test_pickle_quantity(self):
         x = 1.0 * unit.kelvin
         y = pickle.loads(pickle.dumps(x))
 
         assert x == y
 
     @skip_if_missing("uncertainties")
-    def test_pickle_quantity(self):
+    def test_pickle_quantity_uncertainties(self):
         x = (1.0 * unit.kelvin).plus_minus(0.05)
         y = pickle.loads(pickle.dumps(x))
 

--- a/openff/units/units.py
+++ b/openff/units/units.py
@@ -1,13 +1,13 @@
 """
 Core classes for OpenFF Units
 """
-
 import uuid
 import warnings
 from typing import TYPE_CHECKING
 
 import pint
 from openff.utilities import requires_package
+from pint import UnitRegistry as _UnitRegistry
 
 from openff.units.utilities import get_defaults_path
 
@@ -21,44 +21,34 @@ __all__ = [
     "Unit",
 ]
 
-DEFAULT_UNIT_REGISTRY = pint.UnitRegistry(get_defaults_path())
-"""The default unit registry provided by OpenFF Units"""
+# def _unpickle_quantity(cls, *args):
+#     """Rebuild quantity upon unpickling using the application registry."""
+#     return pint._unpickle(Quantity, *args)
+#
+#
+# def _unpickle_unit(cls, *args):
+#     """Rebuild unit upon unpickling using the application registry."""
+#     return pint._unpickle(Unit, *args)
+#
+#
+# def _unpickle_measurement(cls, *args):
+#     """Rebuild measurement upon unpickling using the application registry."""
+#     return pint._unpickle(Measurement, *args)
 
 
-def _unpickle_quantity(cls, *args):
-    """Rebuild quantity upon unpickling using the application registry."""
-    return pint._unpickle(DEFAULT_UNIT_REGISTRY.Quantity, *args)
-
-
-def _unpickle_unit(cls, *args):
-    """Rebuild unit upon unpickling using the application registry."""
-    return pint._unpickle(DEFAULT_UNIT_REGISTRY.Unit, *args)
-
-
-def _unpickle_measurement(cls, *args):
-    """Rebuild measurement upon unpickling using the application registry."""
-    return pint._unpickle(DEFAULT_UNIT_REGISTRY.Measurement, *args)
-
-
-class Unit(DEFAULT_UNIT_REGISTRY.Unit):  # type: ignore[name-defined]
-    """A unit of measure."""
-
-    _REGISTRY = DEFAULT_UNIT_REGISTRY
-
+class Unit:
+    pass
+    """
     def __reduce__(self):
         return _unpickle_unit, (Unit, self._units)
+    """
 
 
-# _MagnitudeType = TypeVar("_MagnitudeType")
-
-
-class Quantity(DEFAULT_UNIT_REGISTRY.Quantity):  # type: ignore[name-defined]
-    """A value with associated units."""
-
-    _REGISTRY = DEFAULT_UNIT_REGISTRY
-
+class Quantity:
+    """
     def __reduce__(self):
         return _unpickle_quantity, (Quantity, self.magnitude, self._units)
+    """
 
     def __dask_tokenize__(self):
         return uuid.uuid4().hex
@@ -82,13 +72,11 @@ class Quantity(DEFAULT_UNIT_REGISTRY.Quantity):  # type: ignore[name-defined]
         return to_openmm(self)
 
 
-class Measurement(DEFAULT_UNIT_REGISTRY.Measurement):  # type: ignore[name-defined]
-    """A value with associated units and uncertainty."""
-
-    _REGISTRY = DEFAULT_UNIT_REGISTRY
-
+class Measurement:
+    """
     def __reduce__(self):
         return _unpickle_measurement, (Measurement, self.magnitude, self._units)
+    """
 
     def __dask_tokenize__(self):
         return uuid.uuid4().hex
@@ -99,9 +87,17 @@ class Measurement(DEFAULT_UNIT_REGISTRY.Measurement):  # type: ignore[name-defin
         return Measurement(values, units)
 
 
-DEFAULT_UNIT_REGISTRY.Unit = Unit
-DEFAULT_UNIT_REGISTRY.Quantity = Quantity
-DEFAULT_UNIT_REGISTRY.Measurement = Measurement
+class UnitRegistry(_UnitRegistry):
+    _quantity_class = Quantity
+    _unit_class = Quantity
+    _measurement_class = Measurement
+
+
+DEFAULT_UNIT_REGISTRY = UnitRegistry(get_defaults_path())
+
+Unit = DEFAULT_UNIT_REGISTRY.Unit
+Quantity = DEFAULT_UNIT_REGISTRY.Quantity
+Measurement = DEFAULT_UNIT_REGISTRY.Measurement
 
 pint.set_application_registry(DEFAULT_UNIT_REGISTRY)
 

--- a/openff/units/units.py
+++ b/openff/units/units.py
@@ -4,13 +4,10 @@ Core classes for OpenFF Units
 
 import uuid
 import warnings
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 import pint
 from openff.utilities import requires_package
-from pint.measurement import _Measurement
-from pint.quantity import _Quantity
-from pint.unit import _Unit
 
 from openff.units.utilities import get_defaults_path
 
@@ -43,7 +40,7 @@ def _unpickle_measurement(cls, *args):
     return pint._unpickle(DEFAULT_UNIT_REGISTRY.Measurement, *args)
 
 
-class Unit(_Unit):
+class Unit(DEFAULT_UNIT_REGISTRY.Unit):  # type: ignore[name-defined]
     """A unit of measure."""
 
     _REGISTRY = DEFAULT_UNIT_REGISTRY
@@ -52,10 +49,10 @@ class Unit(_Unit):
         return _unpickle_unit, (Unit, self._units)
 
 
-_MagnitudeType = TypeVar("_MagnitudeType")
+# _MagnitudeType = TypeVar("_MagnitudeType")
 
 
-class Quantity(_Quantity[_MagnitudeType]):
+class Quantity(DEFAULT_UNIT_REGISTRY.Quantity):  # type: ignore[name-defined]
     """A value with associated units."""
 
     _REGISTRY = DEFAULT_UNIT_REGISTRY
@@ -85,7 +82,7 @@ class Quantity(_Quantity[_MagnitudeType]):
         return to_openmm(self)
 
 
-class Measurement(_Measurement):
+class Measurement(DEFAULT_UNIT_REGISTRY.Measurement):  # type: ignore[name-defined]
     """A value with associated units and uncertainty."""
 
     _REGISTRY = DEFAULT_UNIT_REGISTRY

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ exclude_lines =
 [flake8]
 max-line-length = 119
 ignore = E203,W503
+per-file-ignores =
+    openff/units/units.py:F811
 
 [isort]
 multi_line_output=3

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,14 +49,8 @@ ignore_missing_imports = True
 [mypy-pint.*]
 ignore_missing_imports = True
 
-[mypy-openff.utilities.*]
-ignore_missing_imports = True
-
 [mypy-openmm]
 ignore_missing_imports = True
 
 [mypy-openmm.unit]
-ignore_missing_imports = True
-
-[mypy-openmm.app.element]
 ignore_missing_imports = True


### PR DESCRIPTION
## Description
This PR includes updates for compatibility with Pint 0.20.0

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Re-exports `Quantity`, `Measurement`, and `Unit` mirrored from new locations in the Pint API
  - [x] Removes the `speed` alias, which is now forbidden for reasons I don't follow

## Questions
- [ ] How can I make `Quantity` etc. generic classes again? Mypy was complaining about this.
- [x] Will version 0.20.1 include other changes? We'll see https://github.com/hgrecco/pint/pull/1633/files#diff-22042b3f9bd2818e47c2e60327e7b830b0989ecd80cef90047e5246bfa23c07a

## Status
- [x] Ready to go