### PR TITLE
Bring installation guide in line with ecosystem docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,10 @@ intersphinx_mapping = {
     ),
     "mdtraj": ("https://www.mdtraj.org/1.9.5/", None),
     "openmm": ("http://docs.openmm.org/latest/api-python/", None),
+    "openff.docs": (
+        "https://docs.openforcefield.org/",
+        None,
+    ),
 }
 
 autosummary_generate = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ intersphinx_mapping = {
     "mdtraj": ("https://www.mdtraj.org/1.9.5/", None),
     "openmm": ("http://docs.openmm.org/latest/api-python/", None),
     "openff.docs": (
-        "https://docs.openforcefield.org/",
+        "https://docs.openforcefield.org/en/latest/",
         None,
     ),
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ conda install -c conda-forge openff-units
 
 [Conda]: https://conda.io
 [Mamba]: https://mamba.readthedocs.io
-[ecosystem install docs]: openff.docs:installation
+[OpenFF install docs]: openff.docs:install
 [MambaForge]: https://github.com/conda-forge/miniforge#mambaforge
 
 ## Using OpenFF Units

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,13 +16,15 @@ OpenFF Units is based on [Pint]. Its [`Quantity`], [`Unit`], and [`Measurement`]
 
 ## Installation
 
-We recommend installing OpenFF Units with the [Conda] package manager. If you don't yet have a Conda distribution installed, we recommend [MambaForge] for most users. The `openff-units` package can be installed from Conda Forge:
+We recommend installing OpenFF Units with the [Conda] or [Mamba] package managers. If you don't yet have a Conda distribution installed, we recommend [MambaForge] for most users; see the [ecosystem install docs]. The `openff-units` package can be installed from Conda Forge:
 
 ```shell
 conda install -c conda-forge openff-units
 ```
 
 [Conda]: https://conda.io
+[Mamba]: https://mamba.readthedocs.io
+[ecosystem install docs]: openff.docs:installation
 [MambaForge]: https://github.com/conda-forge/miniforge#mambaforge
 
 ## Using OpenFF Units

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ OpenFF Units is based on [Pint]. Its [`Quantity`], [`Unit`], and [`Measurement`]
 
 ## Installation
 
-We recommend installing OpenFF Units with the [Conda] or [Mamba] package managers. If you don't yet have a Conda distribution installed, we recommend [MambaForge] for most users; see the [ecosystem install docs]. The `openff-units` package can be installed from Conda Forge:
+We recommend installing OpenFF Units with the [Conda] or [Mamba] package managers. If you don't yet have a Conda distribution installed, we recommend [MambaForge] for most users; see the [OpenFF install docs]. The `openff-units` package can be installed from Conda Forge:
 
 ```shell
 conda install -c conda-forge openff-units


### PR DESCRIPTION
## Description
This PR links the installation guide to the new [ecosystem docs](https://docs.openforcefield.org/en/latest/install.html)