### PR TITLE
Add `NUMBERS`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [macOS-latest, ubuntu-latest]
         openmm: ["true", "false"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         pint-version: ["0.21", "0.22"]
 
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}
-      PYTEST_ARGS: -v
+      PYTEST_ARGS: -v -nauto
       COV: --cov=openff/units --cov-report=xml --cov-config=setup.cfg --cov-append
 
     steps:
@@ -55,18 +55,6 @@ jobs:
           exit 1;
         fi
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
-
-    - name: Environment Information
-      run: |
-        conda info
-        conda list
-
     - name: Install package
       run: |
         python setup.py develop --no-deps
@@ -77,16 +65,14 @@ jobs:
       run: |
         mypy -p "openff.units"
 
-    - name: Run unit tests with OpenMM
+    - name: Run unit tests
       if: ${{ matrix.openmm == 'true' }}
       run: |
-        pytest $PYTEST_ARGS $COV openff/units/tests/
+        if [[ ${{ matrix.openmm }} == false ]]; then
+          PYTEST_ARGS +=" --ignore=openff/units/tests/test_openmm.py"
+        fi
 
-    - name: Run unit tests without OpenMM
-      if: ${{ matrix.openmm == 'false' }}
-      run: |
-        pytest $PYTEST_ARGS $COV openff/units/tests/ \
-          --ignore=openff/units/tests/test_openmm.py
+        pytest $PYTEST_ARGS $COV openff/units/tests/
 
     - name: Run docexamples
       if: ${{ matrix.openmm == 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     - name: Optionally install OpenMM
       if: ${{ matrix.openmm == 'true' }}
       run: |
-        micromamba install "openmm >=7.6" -c conda-forge -yq
+        micromamba install "openmm >=7.6" -c conda-forge/label/openmm_rc -c conda-forge -yq
 
     - name: Verify OpenMM is not installed when not expected
       if: ${{ matrix.openmm == 'false' }}

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,7 +1,6 @@
 name: openff-units-test
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python
   - pip

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,7 +11,7 @@ dependencies:
     # Tests
   - pytest
   - pytest-cov
-  - codecov
+  - pytest-xdist
   - uncertainties
 
     # Typing

--- a/openff/units/elements.py
+++ b/openff/units/elements.py
@@ -34,8 +34,10 @@ from openff.units import Quantity, unit
 __all__ = [
     "MASSES",
     "SYMBOLS",
+    "NUMBERS",
 ]
 
+"""Mapping from atomic number to atomic mass"""
 MASSES: Dict[int, Quantity] = {
     # https://github.com/hgrecco/pint/issues/1804
     index + 1: Quantity(mass, unit.dalton)  # type: ignore[call-overload]
@@ -160,8 +162,8 @@ MASSES: Dict[int, Quantity] = {
         ]
     )
 }
-"""Mapping from atomic number to atomic mass"""
 
+"""Mapping from atomic number to element symbol"""
 SYMBOLS: Dict[int, str] = {
     index + 1: symbol
     for index, symbol in enumerate(
@@ -285,3 +287,6 @@ SYMBOLS: Dict[int, str] = {
         ]
     )
 }
+
+"""Mapping from element symbol to atomic number"""
+NUMBERS: dict[str, int] = {val: key for key, val in SYMBOLS.items()}

--- a/openff/units/tests/test_elements.py
+++ b/openff/units/tests/test_elements.py
@@ -1,14 +1,13 @@
+import random
+
 import pytest
 from openff.utilities.testing import skip_if_missing
 
-from openff.units.elements import MASSES, SYMBOLS
+from openff.units.elements import MASSES, NUMBERS, SYMBOLS
 
 
 @skip_if_missing("openmm.unit")
-@pytest.mark.parametrize(
-    "atomic_number",
-    [1, 2],
-)
+@pytest.mark.parametrize("atomic_number", [*range(1, 100)])
 def test_openmm_parity(atomic_number):
     from openmm.app.element import Element
 
@@ -16,3 +15,20 @@ def test_openmm_parity(atomic_number):
 
     assert MASSES[atomic_number].m == openmm_element.mass._value
     assert SYMBOLS[atomic_number] == openmm_element.symbol
+
+
+def test_basic():
+    assert MASSES[1].m == pytest.approx(1.007947)
+    assert MASSES[6].m == pytest.approx(12.01078)
+
+    assert SYMBOLS[1] == "H"
+    assert SYMBOLS[6] == "C"
+
+    assert NUMBERS["Cl"] == 17
+    assert NUMBERS["Cf"] == 98
+
+
+def test_symbol_roundtrip():
+    number = random.randrange(1, 100)
+
+    assert NUMBERS[SYMBOLS[number]] == number


### PR DESCRIPTION
## Description
I find myself doing i.e.

```python
SYMBOLS_TO_ELEMENTS: dict[str, int] = {val: key for key, val in SYMBOLS.items()}
```

downstream. It's easier to just have it here.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go