### PR TITLE
Lazy load objects at top level

### DIFF
--- a/openff/units/units.py
+++ b/openff/units/units.py
@@ -22,6 +22,7 @@ __all__ = [
     "Quantity",
     "Measurement",
     "Unit",
+    "unit",
 ]
 
 
@@ -76,6 +77,8 @@ class UnitRegistry(pint.UnitRegistry):
 
 
 DEFAULT_UNIT_REGISTRY = UnitRegistry(get_defaults_path())
+
+unit = DEFAULT_UNIT_REGISTRY
 
 Unit: _Unit = DEFAULT_UNIT_REGISTRY.Unit
 Quantity: _Quantity = DEFAULT_UNIT_REGISTRY.Quantity


### PR DESCRIPTION
## Description
This PR defers lazy-loads some objects. I think the main impact will be not importing OpenMM unless `openff.units.openmm` is imported.