### PR TITLE
Do not use deprecated `project.license` TOML table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 name = "openff-units"
 description = "A common units module for the OpenFF software stack"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 authors = [ { name = "Open Force Field Initiative", email = "info@openforcefield.org" } ]
 requires-python = ">=3.12"
 classifiers = [


### PR DESCRIPTION
See https://github.com/conda-forge/openff-units-feedstock/actions/runs/30559589434/job/90928851833#step:4:826


```
 │ │   $PREFIX/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
 │ │   !!
 │ │           ********************************************************************************
 │ │           Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
 │ │           By 2027-Feb-18, you need to update your project and remove deprecated calls
 │ │           or your builds will no longer be supported.
 │ │           See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
 │ │           ********************************************************************************
 │ │   !!
 │ │     corresp(dist, value, root_dir)
```

This shows up in many places and I am to roll this out everywhere. The changes should be identical